### PR TITLE
provide IServiceProvider for persistence configuration

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -9,7 +9,7 @@
 
   <!--#region adapt versions here-->
   <MajorVersion>0</MajorVersion>
-  <MinorAndPatchVersion>4.0</MinorAndPatchVersion>
+  <MinorAndPatchVersion>4.1</MinorAndPatchVersion>
   <!--#endregion-->
 
   <AssemblyVersion>$(MajorVersion).0.0</AssemblyVersion>

--- a/src/EventSourcing.Persistence.EntityFramework.SqlServer/Infrastructure/Internal/SqlServerEventStoreOptionsExtension.cs
+++ b/src/EventSourcing.Persistence.EntityFramework.SqlServer/Infrastructure/Internal/SqlServerEventStoreOptionsExtension.cs
@@ -6,9 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EventSourcing.Persistence.EntityFramework.SqlServer.Infrastructure.Internal;
 
-public record SqlServerEventStoreOptionsExtension(string? ConnectionString) : IEventSourcingOptionsExtension
+public record SqlServerEventStoreOptionsExtension(Func<IServiceProvider, string?> ConnectionString) : IEventSourcingOptionsExtension
 {
-    public SqlServerEventStoreOptionsExtension() : this(default(string))
+    public SqlServerEventStoreOptionsExtension() : this(_ => null)
     {
     }
 
@@ -23,9 +23,9 @@ public record SqlServerEventStoreOptionsExtension(string? ConnectionString) : IE
 
     public void ApplyServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddDbContext<EventStoreContext>(options =>
+        serviceCollection.AddDbContext<EventStoreContext>((sp, options) =>
             options
-                .UseSqlServer(ConnectionString, 
+                .UseSqlServer(ConnectionString(sp), 
                     o => o.MigrationsAssembly(typeof(Marker).Assembly.GetName().Name!))
                 .AddInterceptors([new ExclusiveWriteInterceptor()])
         );

--- a/src/EventSourcing.Persistence.EntityFramework.SqlServer/Infrastructure/SqlServerEventStoreOptionsBuilder.cs
+++ b/src/EventSourcing.Persistence.EntityFramework.SqlServer/Infrastructure/SqlServerEventStoreOptionsBuilder.cs
@@ -9,6 +9,11 @@ public class SqlServerEventStoreOptionsBuilder(EventSourcingOptionsBuilder optio
     public SqlServerEventStoreOptionsBuilder ConnectionString(string connectionString) =>
         WithOption(options => options with
         {
+            ConnectionString = _ => connectionString
+        });
+    public SqlServerEventStoreOptionsBuilder ConnectionString(Func<IServiceProvider, string> connectionString) =>
+        WithOption(options => options with
+        {
             ConnectionString = connectionString
         });
 

--- a/src/EventSourcing.Persistence.EntityFramework.SqlServer/SqlServerEventSourcingOptionsExtensions.cs
+++ b/src/EventSourcing.Persistence.EntityFramework.SqlServer/SqlServerEventSourcingOptionsExtensions.cs
@@ -6,7 +6,14 @@ namespace EventSourcing;
 
 public static class SqlServerEventSourcingOptionsExtensions
 {
-    public static EventSourcingOptionsBuilder UseSqlServerEventStore(this EventSourcingOptionsBuilder optionsBuilder, string connectionString, Action<SqlServerEventStoreOptionsBuilder>? sqlServerOptionsAction = null)
+    public static EventSourcingOptionsBuilder UseSqlServerEventStore(
+        this EventSourcingOptionsBuilder optionsBuilder, string connectionString,
+        Action<SqlServerEventStoreOptionsBuilder>? sqlServerOptionsAction = null)
+    {
+        return UseSqlServerEventStore(optionsBuilder, _ => connectionString, sqlServerOptionsAction);
+    }
+    
+    public static EventSourcingOptionsBuilder UseSqlServerEventStore(this EventSourcingOptionsBuilder optionsBuilder, Func<IServiceProvider, string> connectionString, Action<SqlServerEventStoreOptionsBuilder>? sqlServerOptionsAction = null)
     {
         var sqlBuilder = new SqlServerEventStoreOptionsBuilder(optionsBuilder)
             .ConnectionString(connectionString);

--- a/src/EventSourcing.Persistence.EntityFramework.Sqlite/Infrastructure/Internal/SqliteEventStoreOptionsExtension.cs
+++ b/src/EventSourcing.Persistence.EntityFramework.Sqlite/Infrastructure/Internal/SqliteEventStoreOptionsExtension.cs
@@ -6,9 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EventSourcing.Persistence.EntityFramework.Sqlite.Infrastructure.Internal;
 
-public record SqliteEventStoreOptionsExtension(string? ConnectionString) : IEventSourcingOptionsExtension
+public record SqliteEventStoreOptionsExtension(Func<IServiceProvider, string?> ConnectionString) : IEventSourcingOptionsExtension
 {
-    public SqliteEventStoreOptionsExtension() : this(default(string))
+    public SqliteEventStoreOptionsExtension() : this(_ => null)
     {
     }
 
@@ -21,8 +21,8 @@ public record SqliteEventStoreOptionsExtension(string? ConnectionString) : IEven
 
     public void ApplyServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddDbContext<EventStoreContext>(options =>
-            options.UseSqlite(ConnectionString, o => o.MigrationsAssembly(typeof(Marker).Assembly.GetName().Name!))
+        serviceCollection.AddDbContext<EventStoreContext>((sp, options) =>
+            options.UseSqlite(ConnectionString(sp), o => o.MigrationsAssembly(typeof(Marker).Assembly.GetName().Name!))
         );
 
         serviceCollection.AddEntityFrameworkServices();

--- a/src/EventSourcing.Persistence.EntityFramework.Sqlite/Infrastructure/SqliteEventStoreOptionsBuilder.cs
+++ b/src/EventSourcing.Persistence.EntityFramework.Sqlite/Infrastructure/SqliteEventStoreOptionsBuilder.cs
@@ -10,6 +10,11 @@ public class SqliteEventStoreOptionsBuilder(EventSourcingOptionsBuilder optionsB
     public SqliteEventStoreOptionsBuilder ConnectionString(string connectionString) =>
         WithOption(options => options with
         {
+            ConnectionString = _ => connectionString
+        });    
+    public SqliteEventStoreOptionsBuilder ConnectionString(Func<IServiceProvider, string> connectionString) =>
+        WithOption(options => options with
+        {
             ConnectionString = connectionString
         });
 }

--- a/src/EventSourcing.Persistence.EntityFramework.Sqlite/SqliteEventSourcingOptionsExtensions.cs
+++ b/src/EventSourcing.Persistence.EntityFramework.Sqlite/SqliteEventSourcingOptionsExtensions.cs
@@ -6,7 +6,13 @@ namespace EventSourcing;
 
 public static class SqliteEventSourcingOptionsExtensions
 {
-    public static EventSourcingOptionsBuilder UseSqliteEventStore(this EventSourcingOptionsBuilder optionsBuilder, string connectionString, Action<SqliteEventStoreOptionsBuilder>? sqliteOptionsAction = null)
+    public static EventSourcingOptionsBuilder UseSqliteEventStore(
+        this EventSourcingOptionsBuilder optionsBuilder, string connectionString,
+        Action<SqliteEventStoreOptionsBuilder>? sqliteOptionsAction = null)
+    {
+        return UseSqliteEventStore(optionsBuilder, _ => connectionString, sqliteOptionsAction);
+    }
+    public static EventSourcingOptionsBuilder UseSqliteEventStore(this EventSourcingOptionsBuilder optionsBuilder, Func<IServiceProvider, string> connectionString, Action<SqliteEventStoreOptionsBuilder>? sqliteOptionsAction = null)
     {
         var sqlBuilder = new SqliteEventStoreOptionsBuilder(optionsBuilder)
             .ConnectionString(connectionString);


### PR DESCRIPTION
This providers the IServiceCollection to the SqliteEventSourcingOptionsExtensions so that dependencies can be injecteced for configuration